### PR TITLE
fix: delete misused overwride of gummy vitamins

### DIFF
--- a/Kenan-Structured-Modpack/Archived-Mods/PKs_Rebalancing/items/comestible.json
+++ b/Kenan-Structured-Modpack/Archived-Mods/PKs_Rebalancing/items/comestible.json
@@ -208,25 +208,6 @@
     "flags": [ "NPC_SAFE" ]
   },
   {
-    "id": "gummy_vitamins",
-    "copy-from": "vitamins",
-    "type": "COMESTIBLE",
-    "name": { "str": "gummy vitamin" },
-    "description": "Essential dietary nutrients conveniently packaged in a fruit-flavored chewy candy form to disguise the ionized iron contained within.  An option of last resort when a balanced diet is not possible, this will also cleanse the body of minor toxins and radioactive particles.  Excess use can cause hypervitaminosis and in some cases overdose.",
-    "calories": 9,
-    "stim": -1,
-    "fun": 4,
-    "charges": 10,
-    "stack_size": 10,
-    "use_action": {
-      "type": "consume_drug",
-      "activation_message": "You take the %s.",
-      "effects": [ { "id": "chelated_iron", "duration": 600 }, { "id": "rad_reduce", "duration": 600 } ],
-      "vitamins": [ [ "calcium", 25, 50 ], [ "iron", 25, 50 ], [ "vitA", 25, 50 ], [ "vitB", 25, 50 ], [ "vitC", 25, 50 ] ]
-    },
-    "flags": [ "NPC_SAFE" ]
-  },
-  {
     "id": "prussian_blue",
     "type": "COMESTIBLE",
     "comestible_type": "MED",


### PR DESCRIPTION
This is causing https://discourse.cataclysmdda.org/t/how-to-debug-tried-to-put-an-item-mre-bag-count-1-in-a-container/27583