### PR TITLE
Update to resolve errors caused by upstream changes

### DIFF
--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-100%_monster_resilience_version/Locations/City_Locations.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-100%_monster_resilience_version/Locations/City_Locations.json
@@ -32,7 +32,7 @@
         "...........#y CC  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "terrain": { "G": "t_grass" },
       "place_items": [

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-140%_monster_resilience_version/Locations/City_Locations.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-140%_monster_resilience_version/Locations/City_Locations.json
@@ -32,7 +32,7 @@
         "...........#y CC  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "terrain": { "G": "t_grass" },
       "place_items": [

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-175%_monster_resilience_version/Locations/City_Locations.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/BL9-175%_monster_resilience_version/Locations/City_Locations.json
@@ -32,7 +32,7 @@
         "...........#y CC  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "terrain": { "G": "t_grass" },
       "place_items": [

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/traits/attunements.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/MagicRevampAdditions/traits/attunements.json
@@ -11,7 +11,6 @@
     "description": "With the mechanically-minded Technomancer and the sheer power of lightning from a Stormshaper, the Artificer has a unique confluence of skills and spells to be perfect for invention.  While modern inventions and machines have won out in a modern society, after a Cataclysm one has a chance to go back to roots of things.  To make weird gadgets that are just as likely to explode as explode the thing you're pointing at.",
     "prereqs": [ "STORMSHAPER", "TECHNOMANCER" ],
     "spells_learned": [ [ "spy_wasp", 5 ], [ "artificer_toolkit", 5 ] ],
-    "crafting_speed_multiplier": 1.2,
     "delete": {
       "cancels": [
         "ALCHEMIST",
@@ -97,7 +96,6 @@
     "description": "The Biotek is quite simply the marriage of technology and flesh.  It was not even discovered as an attunement until recent times due to the great advancements in technology in the last 50 years.  The Biotek is unique as it is the only known attunement that warps the Aethereum in such a way as to allow cybernetics to coincide with magical abilities, to an extent.",
     "prereqs": [ "BIOMANCER", "TECHNOMANCER" ],
     "spells_learned": [ [ "nitro_boost", 5 ], [ "biotek_healing", 5 ] ],
-    "bionic_mana_penalty": 0.5,
     "bionic_slot_bonuses": { "torso": 20 },
     "delete": {
       "cancels": [
@@ -423,7 +421,7 @@
         "WITHER_MAGE"
       ]
     },
-    "flags": [ "ATTUNEMENT" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "id": "GAIAS_CHOSEN",
@@ -602,7 +600,6 @@
     "valid": false,
     "description": "The Technomancer specializes in augmenting humans without actually modifying them; and the Overclocker takes the heat aptitude of a Kelvinist and puts that to work.  You are able to think significantly faster, and are able to align your ley lines for spellcasting faster as a result.",
     "prereqs": [ "KELVINIST", "TECHNOMANCER" ],
-    "casting_time_multiplier": 0.75,
     "spells_learned": [ [ "overaccelerate", 5 ], [ "overclocker_drive", 5 ] ],
     "delete": {
       "cancels": [

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/Miscellaneous_Magiclysm_Expansions/mutagenics/mutations/magic.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/Miscellaneous_Magiclysm_Expansions/mutagenics/mutations/magic.json
@@ -24,7 +24,7 @@
   {
     "type": "mutation",
     "id": "MANA_ADD1",
-    "copy-from": "MANA_ADD1',
+    "copy-from": "MANA_ADD1",
     "name": { "str": "Lesser Mana Efficiency" },
     "points": 1,
     "description": "You are able to store a little more mana in your body than usual.",

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/Miscellaneous_Magiclysm_Expansions/mutagenics/mutations/orc.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/Miscellaneous_Magiclysm_Expansions/mutagenics/mutations/orc.json
@@ -46,8 +46,15 @@
         "cut": 1
       }
     ],
-    "passive_mods": { "str_mod": 2 },
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.05 }, { "value": "MAX_HP", "multiply": 0.5 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "CARRY_WEIGHT", "multiply": 0.05 },
+          { "value": "MAX_HP", "multiply": 0.5 },
+          { "value": "STRENGTH", "add": 2 }
+        ]
+      }
+    ],
     "social_modifiers": { "intimidate": 4 }
   },
   {
@@ -73,8 +80,15 @@
         "cut": 3
       }
     ],
-    "passive_mods": { "str_mod": 4 },
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 1.1 }, { "value": "MAX_HP", "multiply": 1 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "CARRY_WEIGHT", "multiply": 1.1 },
+          { "value": "MAX_HP", "multiply": 1.0 },
+          { "value": "STRENGTH", "add": 4 }
+        ]
+      }
+    ],
     "social_modifiers": { "intimidate": 7 }
   },
   {

--- a/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/secronom_lore_expansion/Modification Files/Others/secro_mutation.json
+++ b/Kenan-Structured-Modpack/High-Maintenance-Huge-Mods/secronom_lore_expansion/Modification Files/Others/secro_mutation.json
@@ -61,7 +61,7 @@
     ],
     "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
     "encumbrance_covered": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
-    "rand_bash_bonus": { "min": 1, "max": 3 },
+    "enchantments": [ { "values": [ { "value": "ITEM_DAMAGE_BASH", "add": 2 }]}],
     "attacks": [
       {
         "attack_text_u": "You slap %s with your tendrils",
@@ -97,7 +97,6 @@
     "leads_to": [ "SECRO_TENDRIL_THICK_THRESHOLD" ],
     "encumbrance_always": [ [ "hand_l", 45 ], [ "hand_r", 45 ] ],
     "encumbrance_covered": [ [ "hand_l", 55 ], [ "hand_r", 55 ] ],
-    "rand_bash_bonus": { "min": 3, "max": 8 },
     "attacks": [
       {
         "attack_text_u": "You slap %s with your thick tendrils",
@@ -115,7 +114,14 @@
       }
     ],
     "armor": [ { "parts": [ "arm_l", "arm_r" ], "bash": 6 } ],
-    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": -2 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "DEXTERITY", "add": -2 },
+          { "value": "ITEM_DAMAGE_BASH", "add": 5.5}
+        ]
+      }
+    ],
     "category": [ "SECRONOM_EX" ]
   },
   {
@@ -156,7 +162,6 @@
       [ "arm_l", 25 ],
       [ "arm_r", 25 ]
     ],
-    "rand_bash_bonus": { "min": 1, "max": 2 },
     "attacks": [
       {
         "attack_text_u": "You slap %s with your tendrils",
@@ -188,7 +193,15 @@
       }
     ],
     "armor": [ { "parts": [ "arm_l", "arm_r" ], "bash": 1 }, { "parts": "ALL", "bash": 2 } ],
-    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 1 }, { "value": "ATTACK_SPEED", "multiply": 0.05 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "DEXTERITY", "add": 1 },
+          { "value": "ATTACK_SPEED", "multiply": 0.05 },
+          { "value": "ITEM_DAMAGE_BASH", "add": 1.5 }
+        ]
+      }
+    ],
     "category": [ "SECRONOM_EX" ]
   },
   {
@@ -204,8 +217,14 @@
     "threshreq": [ "THRESH_SECRONOM_EX" ],
     "cancels": [ "SECRO_BLADE_SHARP_THRESHOLD", "SECRO_BLADE_SERRATED_THRESHOLD", "SECRO_TENDRIL_TENT_THRESHOLD" ],
     "armor": [ { "parts": [ "arm_l", "arm_r" ], "bash": 4 } ],
-    "bash_dmg_bonus": 4,
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "ITEM_DAMAGE_BASH", "add": 4 }
+        ]
+      }
+    ],
     "category": [ "SECRONOM_EX" ]
   },
   {
@@ -250,7 +269,7 @@
       "SECRO_BLADE_SERRATED_THRESHOLD"
     ],
     "encumbrance_always": [ [ "hand_l", 100 ] ],
-    "rand_bash_bonus": { "min": 4, "max": 8 },
+    "enchantments": [ { "values": [ { "value": "ITEM_DAMAGE_BASH", "add": 6 } ] } ],
     "armor": [ { "parts": "arm_l", "bash": 10, "cut": 10, "stab": 10 } ],
     "category": [ "SECRONOM_EX" ]
   },
@@ -269,9 +288,15 @@
     "prereqs": [ "SECRO_BLADE_L" ],
     "leads_to": [ "SECRO_BLADE_SHARP_THRESHOLD" ],
     "encumbrance_always": [ [ "hand_l", 100 ] ],
-    "rand_cut_bonus": { "min": 4, "max": 12 },
     "armor": [ { "parts": "arm_l", "bash": 6, "cut": 6, "stab": 6 } ],
-    "enchantments": [ { "values": [ { "value": "ATTACK_SPEED", "multiply": 0.1 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "ATTACK_SPEED", "multiply": 0.1 },
+          { "value": "ITEM_DAMAGE_CUT", "add": 8 }
+        ]
+      }
+    ],
     "category": [ "SECRONOM_EX" ]
   },
   {
@@ -289,10 +314,16 @@
     "prereqs": [ "SECRO_BLADE_L" ],
     "leads_to": [ "SECRO_BLADE_SERRATED_THRESHOLD" ],
     "encumbrance_always": [ [ "hand_l", 100 ] ],
-    "rand_cut_bonus": { "min": 3, "max": 8 },
-    "rand_bash_bonus": { "min": 3, "max": 8 },
     "armor": [ { "parts": "arm_l", "bash": 14, "cut": 14, "stab": 14 } ],
-    "enchantments": [ { "values": [ { "value": "ATTACK_SPEED", "multiply": -0.05 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "ATTACK_SPEED", "multiply": -0.05 },
+          { "value": "ITEM_DAMAGE_BASH", "add": 5.5 },
+          { "value": "ITEM_DAMAGE_CUT", "add": 5.5 }
+        ]
+      }
+    ],
     "category": [ "SECRONOM_EX" ]
   },
   {


### PR DESCRIPTION
Resolves issues from https://github.com/CleverRaven/Cataclysm-DDA/pull/72173 etc. 
Only these mods were checked:
- BL9
- MagicRevampAdditions
- Miscellaneous_Magiclysm_Expansions
- MMA_Mods_Extension
- secronom
- secronom_lore_expansion